### PR TITLE
hotspot attribute + child elements

### DIFF
--- a/packages/dev/core/src/Meshes/abstractMesh.hotSpot.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.hotSpot.ts
@@ -1,11 +1,11 @@
-import { Vector2, Vector3, TmpVectors, Matrix } from "../Maths/math.vector";
+import { Vector3, TmpVectors, Matrix } from "../Maths/math.vector";
 import type { AbstractMesh } from "./abstractMesh";
 import { VertexBuffer } from "../Buffers/buffer";
 
 /**
  * Data for mesh hotspot computation
  */
-export class HotSpotQuery {
+export type HotSpotQuery = {
     /**
      * 3 point indices
      */
@@ -14,21 +14,7 @@ export class HotSpotQuery {
      * 3 barycentric coordinates
      */
     barycentric: [number, number, number];
-}
-
-/**
- * Result from a HotSpot query on the scene
- */
-export class HotSpot {
-    /**
-     * 2D screen position
-     */
-    screenPosition = new Vector2();
-    /**
-     * 3D world position
-     */
-    worldPosition = new Vector3();
-}
+};
 
 /**
  * Return a transformed local position from a mesh and vertex index

--- a/packages/dev/core/src/Meshes/index.ts
+++ b/packages/dev/core/src/Meshes/index.ts
@@ -2,7 +2,7 @@
 /* eslint-disable import/no-internal-modules */
 export * from "./abstractMesh";
 import "./abstractMesh.decalMap";
-import "./abstractMesh.hotSpot";
+export * from "./abstractMesh.hotSpot";
 export * from "./Compression/index";
 export * from "./csg";
 export * from "./meshUVSpaceRenderer";

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -5,6 +5,7 @@ import type {
     AutoRotationBehavior,
     Camera,
     FramingBehavior,
+    HotSpotQuery,
     IDisposable,
     LoadAssetContainerOptions,
     Mesh,
@@ -30,7 +31,6 @@ import { Scene, ScenePerformancePriority } from "core/scene";
 import { registerBuiltInLoaders } from "loaders/dynamic";
 import { Viewport } from "core/Maths/math.viewport";
 import { GetHotSpotToRef } from "core/Meshes/abstractMesh.hotSpot";
-import type { HotSpotQuery } from "core/Meshes/abstractMesh.hotSpot";
 
 function throwIfAborted(...abortSignals: (Nullable<AbortSignal> | undefined)[]): void {
     for (const signal of abortSignals) {
@@ -94,10 +94,17 @@ export type ViewerOptions = Partial<
         }>
 >;
 
+export type ViewerHotSpotQuery = {
+    /**
+     * The index of the mesh within the loaded model.
+     */
+    meshIndex: number;
+} & HotSpotQuery;
+
 /**
  * Information computed from the hot spot surface data, canvas and mesh datas
  */
-export interface HotSpotPositions {
+export type ViewerHotSpot = {
     /**
      * 2D canvas position in pixels
      */
@@ -106,7 +113,7 @@ export interface HotSpotPositions {
      * 3D world coordinates
      */
     worldPosition: [number, number, number];
-}
+};
 
 /**
  * Provides an experience for viewing a single 3D model.
@@ -502,18 +509,17 @@ export class Viewer implements IDisposable {
 
     /**
      * retrun world and canvas coordinates of an hot spot
-     * @param meshIndex mesh index in asset container
-     * @param hotSpotQuery a surface information to query the hot spot positions
+     * @param hotSpotQuery mesh index and surface information to query the hot spot positions
      * @param res Query a Hot Spot and does the conversion for Babylon Hot spot to a more generic HotSpotPositions, without Vector types
      * @returns true if hotspot found
      */
-    public getHotSpotToRef(meshIndex: number, hotSpotQuery: HotSpotQuery, res: HotSpotPositions): boolean {
+    public getHotSpotToRef(hotSpotQuery: Readonly<ViewerHotSpotQuery>, res: ViewerHotSpot): boolean {
         if (!this._details.model) {
             return false;
         }
         const worldPos = TmpVectors.Vector3[1];
         const screenPos = TmpVectors.Vector3[0];
-        const mesh = this._details.model.meshes[meshIndex];
+        const mesh = this._details.model.meshes[hotSpotQuery.meshIndex];
         if (!mesh) {
             return false;
         }

--- a/packages/tools/viewer-alpha/test/apps/web/index.html
+++ b/packages/tools/viewer-alpha/test/apps/web/index.html
@@ -69,18 +69,18 @@
             source="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb"
             environment="../../../../../public/@babylonjs/viewer-alpha/assets/photoStudio.env"
             animation-speed="1.5"
+            hotspots="testHotSpot1 1 228 113 111 0.217 0.341 0.442"
         >
             <!-- <div slot="tool-bar" style="position: absolute; top: 12px; left: 12px; width: 100px; height: 36px">
                 <button onclick="document.querySelector('babylon-viewer').toggleAnimation()">Toggle Animation</button>
             </div> -->
-
-            <div slot="hotspot" class="hotspot" data-surface="1 228 113 111 0.217 0.341 0.442"></div>
+            <svg id="lines" style="position: absolute; width: 100%; height: 100%" xmlns="http://www.w3.org/2000/svg" class="lineContainer">
+                <line class="line"></line>
+            </svg>
         </babylon-viewer>
         <button class="toggle-dom-button" onclick="onToggleDOM()">Toggle DOM</button>
         <button class="toggle-engine-button" onclick="onToggleEngine()">Toggle Engine</button>
-        <svg id="lines" style="position: absolute; top: 0; left: 0" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg" class="lineContainer">
-            <line class="line"></line>
-        </svg>
+
         <button id="anchor-button" class="toggle-hotspot-button" onclick="onToggleHotSpot()">Toggle Hot Spot</button>
         <script type="module" src="/packages/tools/viewer-alpha/src/index.ts"></script>
         <script>
@@ -136,7 +136,7 @@
             // use requestAnimationFrame to update with renderer
             const startHotSpotLinesRenderLoop = () => {
                 const hotspotBaseRect = document.querySelector("#anchor-button").getBoundingClientRect();
-                drawHotSpotLine(lines[0], "hotspot", hotspotBaseRect);
+                drawHotSpotLine(lines[0], "testHotSpot1", hotspotBaseRect);
                 if (hotspotVisible) {
                     requestAnimationFrame(startHotSpotLinesRenderLoop);
                 }


### PR DESCRIPTION
I tried a few things I mentioned in the chat:
1. Specify hotspot data in an attribute (instead of child elements with slot and data-surface attributes).
2. hotspots as a property exposes structured data, which makes it easy to use from JS as well.
3. <babylon-viewer> can have arbitrary child elements (which is convenient for hotspot related elements, but still allows you to create have hotspot related elements outside of the bounds of the view if it makes sense for your scenario).

Separately, we could introduce a <babylon-hotspot> custom element that could be a child and we would automatically link it up with the hotspot data. This would make it really easy to add basic hotspot elements.

I think this is pretty good, but let me know what you think. 